### PR TITLE
Scroll lock bug

### DIFF
--- a/src/components/CollapsibleNav/collapsiblenav.js
+++ b/src/components/CollapsibleNav/collapsiblenav.js
@@ -3,23 +3,23 @@ import { Link } from 'gatsby';
 
 import { collapsibleNavContainer, collapsibleNav, collapsibleNavOpen, navItemList, navItem, navLink, navOpen, closed } from './collapsiblenav.module.css';
 
-const CollapsibleNav = ({ isNavOpen }) => {
+const CollapsibleNav = ({ isNavOpen, onLinkClick }) => {
 
-  function handleNavLinkClick () {
-    document.body.classList.toggle('menu-open');
-  }
+  // function handleNavLinkClick () {
+  //   document.body.classList.toggle('menu-open');
+  // }
 
   return (
     <div className={isNavOpen ? collapsibleNavOpen : collapsibleNav}>
       <ul className={navItemList}>
         <li className={navItem}>
-        <Link onClick={handleNavLinkClick} className={navLink} to="/">Home</Link>
+        <Link onClick={onLinkClick} className={navLink} to="/">Home</Link>
         </li>
         <li className={navItem}>
-        <Link onClick={handleNavLinkClick} className={navLink} to="/blog">Blog</Link>
+        <Link onClick={onLinkClick} className={navLink} to="/blog">Blog</Link>
         </li>
         <li className={navItem}>
-        <Link onClick={handleNavLinkClick} className={navLink} to="/about">About</Link>
+        <Link onClick={onLinkClick} className={navLink} to="/about">About</Link>
         </li>
       </ul>
     </div>

--- a/src/components/CollapsibleNav/collapsiblenav.js
+++ b/src/components/CollapsibleNav/collapsiblenav.js
@@ -4,17 +4,22 @@ import { Link } from 'gatsby';
 import { collapsibleNavContainer, collapsibleNav, collapsibleNavOpen, navItemList, navItem, navLink, navOpen, closed } from './collapsiblenav.module.css';
 
 const CollapsibleNav = ({ isNavOpen }) => {
+
+  function handleNavLinkClick () {
+    document.body.classList.toggle('menu-open');
+  }
+
   return (
     <div className={isNavOpen ? collapsibleNavOpen : collapsibleNav}>
       <ul className={navItemList}>
         <li className={navItem}>
-        <Link className={navLink} to="/">Home</Link>
+        <Link onClick={handleNavLinkClick} className={navLink} to="/">Home</Link>
         </li>
         <li className={navItem}>
-        <Link className={navLink} to="/blog">Blog</Link>
+        <Link onClick={handleNavLinkClick} className={navLink} to="/blog">Blog</Link>
         </li>
         <li className={navItem}>
-        <Link className={navLink} to="/about">About</Link>
+        <Link onClick={handleNavLinkClick} className={navLink} to="/about">About</Link>
         </li>
       </ul>
     </div>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -30,6 +30,7 @@ const Layout = ({ pageTitle, children }) => {
     document.body.classList.toggle('menu-open');
     window.scrollTo(0,0);
   }
+
   const data = useStaticQuery(graphql`
     query MyQuery {
       site {

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -31,6 +31,11 @@ const Layout = ({ pageTitle, children }) => {
     window.scrollTo(0,0);
   }
 
+  function handleNavLinkClick () {
+    setIsModalOpen(!isModalOpen);
+    document.body.classList.toggle('menu-open');
+  }
+
   const data = useStaticQuery(graphql`
     query MyQuery {
       site {
@@ -77,7 +82,7 @@ const Layout = ({ pageTitle, children }) => {
             </li>
           </ul>
         </nav>
-      <CollapsibleNav isNavOpen={isModalOpen}/>
+      <CollapsibleNav onLinkClick={handleNavLinkClick} isNavOpen={isModalOpen}/>
       <div className={container}>
         <main>
           <div className={contentContainer}>

--- a/src/components/layout.module.css
+++ b/src/components/layout.module.css
@@ -72,7 +72,7 @@
   align-items: center;
   justify-content: space-around;
   height: 45px;
-  background-color: #7a04eb;
+  background: #7a04eb;
   padding-left: 30px;
   transform-origin: center;
   z-index: 3;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { Link, graphql } from 'gatsby';
 import Layout from '../components/layout';
 import { StaticImage, GatsbyImage } from 'gatsby-plugin-image';
@@ -6,6 +6,9 @@ import { homepageImg, contentContainer, pageHeader, pageHeaderSub, blogTitle, bl
 
 const IndexPage = ({ data }) => {
   const recentBlogs = data.allMdx.nodes;
+  // useEffect(() => {
+  //   document.body.classList.remove('menu-open');
+  // })
   return (
       <div className="index-page">
         <Layout pageTitle="Home Page">


### PR DESCRIPTION
Fixed bug where after clicking a link in the collapsible nav, the menu-open class would stay on the body element which locked out scrolling. After this was fixed I also added an event handler function to the links in the collapsible nav to close the menu when a link was clicked even if the link clicked was for the current page. This was done to prevent the user ending up with the menu still open but being allowed to scroll the page behind.